### PR TITLE
Fix mode selector font on iOS

### DIFF
--- a/src/mode-selector.js
+++ b/src/mode-selector.js
@@ -36,6 +36,7 @@ export default props => {
           aria-checked={m === mode}
           sx={{
             appearance: 'none',
+            fontFamily: 'inherit',
             fontSize: 0,
             fontWeight: 'bold',
             m: 0,


### PR DESCRIPTION
Before, using `sans-serif`, the default:
![46578972-71A8-4D36-A31D-F148D2D940CA](https://user-images.githubusercontent.com/5074763/62904920-38c79b80-bd36-11e9-9386-d3c91197a830.jpeg)

After:
![349C9DFB-7AE8-450D-A76A-F5FA3627FF48](https://user-images.githubusercontent.com/5074763/62904921-38c79b80-bd36-11e9-9959-6e39ae10abba.jpeg)
