### PR TITLE
Add Holy Grail layout

### DIFF
--- a/src/examples/holy-grail.js
+++ b/src/examples/holy-grail.js
@@ -1,0 +1,20 @@
+/** @jsx jsx */
+import { jsx, Box, Flex } from "../code";
+
+export default () => (
+  <Flex sx={{ flexDirection: "column", minHeight: "100vh" }}>
+    <Box>Header</Box>
+    <Flex sx={{ flex: 1, flexDirection: ["column", "row"] }}>
+      <Box as="main" sx={{ flex: 1 }}>
+        Main Content
+      </Box>
+      <Box as="nav" sx={{ flexBasis: ["auto", "12em"], order: -1 }}>
+        Navigation
+      </Box>
+      <Box as="aside" sx={{ flexBasis: ["auto", "12em"] }}>
+        Advertisements
+      </Box>
+    </Flex>
+    <Box as="footer">Footer</Box>
+  </Flex>
+);

--- a/src/examples/holy-grail.js
+++ b/src/examples/holy-grail.js
@@ -5,16 +5,10 @@ export default () => (
   <Flex sx={{ flexDirection: "column", minHeight: "100vh" }}>
     <Box>Header</Box>
     <Flex sx={{ flex: 1, flexDirection: ["column", "row"] }}>
-      <Box as="main" sx={{ flex: 1 }}>
-        Main Content
-      </Box>
-      <Box as="nav" sx={{ flexBasis: ["auto", "12em"], order: -1 }}>
-        Navigation
-      </Box>
-      <Box as="aside" sx={{ flexBasis: ["auto", "12em"] }}>
-        Advertisements
-      </Box>
+      <Box sx={{ flex: 1 }}>Main Content</Box>
+      <Box sx={{ flexBasis: ["auto", 64], order: -1 }}>Nav</Box>
+      <Box sx={{ flexBasis: ["auto", 64] }}>Ads</Box>
     </Flex>
-    <Box as="footer">Footer</Box>
+    <Box>Footer</Box>
   </Flex>
 );

--- a/src/nav.js
+++ b/src/nav.js
@@ -6,4 +6,5 @@ export default [
   { name: 'Stack', path: '/stack' },
   { name: 'Sticky Footer', path: '/sticky-footer' },
   { name: 'Masonry', path: '/masonry' },
+  { name: 'Holy Grail', path: '/holy-grail' },
 ]

--- a/src/pages/holy-grail.mdx
+++ b/src/pages/holy-grail.mdx
@@ -1,0 +1,14 @@
+---
+title: Holy Grail
+---
+
+import { Editor } from '..'
+import HolyGrail from '../examples/holy-grail'
+
+# Holy Grail
+
+As per [Wikipedia](https://en.wikipedia.org/wiki/Holy_grail_(web_design))
+
+> The holy grail refers to a web page layout which has multiple, equal height columns that are defined with style sheets. It is commonly desired and implemented, but for many years, the various ways in which it could be implemented with the current technologies all had drawbacks. Because of this, finding an optimal implementation was likened to searching for the elusive Holy Grail.
+
+<Editor component={HolyGrail} />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -139,7 +139,6 @@ export default props => {
           title='Holy Grail'
           component={HolyGrail}
           href='/holy-grail'
-          zoom={1/4}
         />
       </Grid>
       <Styled.p sx={{ mb: 5 }}>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -11,6 +11,7 @@ import Container from '../examples/container'
 import Stack from '../examples/stack'
 import StickyFooter from '../examples/sticky-footer'
 import Masonry from '../examples/masonry'
+import HolyGrail from '../examples/holy-grail'
 
 const Grid = ({
   width = 320,
@@ -132,6 +133,12 @@ export default props => {
           title='Masonry'
           component={Masonry}
           href='/masonry'
+          zoom={1/4}
+        />
+        <Card
+          title='Holy Grail'
+          component={HolyGrail}
+          href='/holy-grail'
           zoom={1/4}
         />
       </Grid>


### PR DESCRIPTION
Howdy!

Super cool project, so I thought I'd add a classic layout to the list: the "holy grail."

<img width="1439" alt="Screen Shot 2019-08-15 at 1 37 04 PM" src="https://user-images.githubusercontent.com/5148596/63114176-2c278b00-bf62-11e9-93af-5c85f485aaed.png">

Not sure if I structured things correctly, and I have a few open questions for you.
- Does the `as` prop actually change the rendered tag for `Box` components? I was hoping for the resulting markup to be as semantically "correct" as possible, but I worry I might be using the wrong API for changing tags.
- On the home page, the height of the `HolyGrail` component seems oddly constrained, insofar as I expect it to occupy as much of the preview card as possible (like in the "Sticky Footer" example) Any ideas?

❤️ 