### PR TITLE
Add CSS Grid fork of Holy Grail Layout

### DIFF
--- a/src/examples/holy-grail-grid.js
+++ b/src/examples/holy-grail-grid.js
@@ -1,0 +1,26 @@
+/** @jsx jsx */
+import { jsx, Box } from '../code';
+
+export default () => (
+  <Box
+    sx={{
+      display: 'grid',
+      minHeight: '100vh',
+      gridTemplateAreas: [
+        `"header" "nav" "main" "ads" "footer"`,
+        `"header header header" "nav main ads" "footer footer footer"`
+      ],
+      gridTemplateColumns: ['1fr', '64px 1fr 64px'],
+      gridTemplateRows: [
+        'min-content min-content 1fr min-content min-content',
+        'min-content 1fr min-content'
+      ]
+    }}
+  >
+    <Box sx={{ gridArea: 'header' }}>Header</Box>
+    <Box sx={{ gridArea: 'main' }}>Main Content</Box>
+    <Box sx={{ gridArea: 'nav' }}>Nav</Box>
+    <Box sx={{ gridArea: 'ads' }}>Ads</Box>
+    <Box sx={{ gridArea: 'footer' }}>Footer</Box>
+  </Box>
+);

--- a/src/examples/holy-grail.js
+++ b/src/examples/holy-grail.js
@@ -5,7 +5,7 @@ export default () => (
   <Flex sx={{ flexDirection: "column", minHeight: "100vh" }}>
     <Box>Header</Box>
     <Flex sx={{ flex: 1, flexDirection: ["column", "row"] }}>
-      <Box sx={{ flex: 1 }}>Main Content</Box>
+      <Box sx={{ flex: 1, minWidth: 0 }}>Main Content</Box>
       <Box sx={{ flexBasis: ["auto", 64], order: -1 }}>Nav</Box>
       <Box sx={{ flexBasis: ["auto", 64] }}>Ads</Box>
     </Flex>

--- a/src/nav.js
+++ b/src/nav.js
@@ -7,4 +7,5 @@ export default [
   { name: 'Sticky Footer', path: '/sticky-footer' },
   { name: 'Masonry', path: '/masonry' },
   { name: 'Holy Grail', path: '/holy-grail' },
+  { name: 'Holy Grail (Grid)', path: '/holy-grail-grid' },
 ]

--- a/src/pages/holy-grail-grid.mdx
+++ b/src/pages/holy-grail-grid.mdx
@@ -1,0 +1,12 @@
+---
+title: Holy Grail (Grid)
+---
+
+import { Editor } from '..'
+import HolyGrailGrid from '../examples/holy-grail-grid'
+
+# Holy Grail (Grid)
+
+A CSS Grid fork of the [flexbox implementation of Holy Grail](/holy-grail)
+
+<Editor component={HolyGrailGrid} />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -12,6 +12,7 @@ import Stack from '../examples/stack'
 import StickyFooter from '../examples/sticky-footer'
 import Masonry from '../examples/masonry'
 import HolyGrail from '../examples/holy-grail'
+import HolyGrailGrid from '../examples/holy-grail-grid'
 
 const Grid = ({
   width = 320,
@@ -139,6 +140,11 @@ export default props => {
           title='Holy Grail'
           component={HolyGrail}
           href='/holy-grail'
+        />
+        <Card
+          title='Holy Grail (Grid)'
+          component={HolyGrailGrid}
+          href='/holy-grail-grid'
         />
       </Grid>
       <Styled.p sx={{ mb: 5 }}>


### PR DESCRIPTION
A tale of two commits:

e99f01d: A CSS tweak per some advice on [Twitter](https://twitter.com/dam/status/1162104464737619968?s=20)

366b295: Adding the Grid fork of the Flex implementation.

I omitted the `min-width: 0` from the Grid implementation, since I admittedly don't fully understand why that's necessary 🤷‍♂ 

CSS is hard.

🎊 