### PR TITLE
Fix preview zoom

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -30,7 +30,7 @@ const Card = ({
   component,
   title,
   href,
-  zoom = 3/4,
+  zoom = 1/2,
   ...props
 }) =>
   <Link


### PR DESCRIPTION
This PR fixes a zoom issue for the main page (this with previews). The main reason of this fix is that `Sidebar` and `Tiles by Width` aren't displaying properly right now 😢 

Before fix:
<img width="1677" alt="image" src="https://user-images.githubusercontent.com/1303365/63157229-c47f4780-c016-11e9-85ca-bf10b92f39e8.png">

After fix:
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/1303365/63157253-d365fa00-c016-11e9-916f-3d69e467060c.png">

